### PR TITLE
Test PR merge message settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # Test repository
 
-Try "Default to pull request title" setting, forgot PR.
+Test


### PR DESCRIPTION
This PR tests different merge message settings.

**Problem**: We write long and nice summaries of the PRs to Github's PR description fields, which is this exact field. However, with the current "Default message" setting, the PR description is not included in the merge commit message by default.

By default, the merge commit title is a title that consists of the branch name and PR number, and the commit description is the PR title. For this example PR:

* Title: 
* Description: 

In the default message, PR description is not included.

**Solution**

If we change the setting to "PR title and description", the commit message looks like this:

* Title: `Test PR merge message settings (#3)`
* Description: 

```
This PR tests different merge message settings. 

**Problem**: We write long and nice summaries of the PRs to Github's PR [...and so on]
```